### PR TITLE
Move documentation to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# jquery-ui Plugin
+
+<strong>Obselete:</strong> This plugin has been replaced with the [jQuery
+Plugin](https://plugins.jenkins.io/jquery/). Please
+remove this plugin from your installation if no plugins depend on it.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins jQuery UI plugin</name>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/jQuery+UI+Plugin</url>
+  <url>https://github.com/jenkinsci/jquery-ui-plugin</url>
 
   <developers>
     <developer>
@@ -31,7 +31,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
@@ -43,7 +43,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
Only move the deprecation warning. The changelog has no useful information whatsoever.